### PR TITLE
Add rust-version to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "5.0.2"
 edition = "2021"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>"]
 license = "MIT OR Apache-2.0"
+rust-version = "1.82.0"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION
The `iter::repeat_n` you used in the last commit was stabilized on Rust version `1.82.0`. In general, I believe that it is bad practice to make such breaking changes without the presence of the `rust-version` field in `Cargo.toml`