### PR TITLE
Switch back from using `repeat_n` and `core::error::Error`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "5.0.2"
 edition = "2021"
 authors = ["Johanna Sörngård <jsorngard@gmail.com>"]
 license = "MIT OR Apache-2.0"
+rust-version = "1.78.0"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ codegen-units = 1
 
 [profile.dev.package."*"]
 # Enable optimization of dependencies also in debug mode
-opt-level=3
+opt-level = 3
 
 [features]
 # Enable this feature to run all memory reads and writes in parallel.

--- a/src/detector.rs
+++ b/src/detector.rs
@@ -1,7 +1,4 @@
-use core::{
-    iter::repeat_n,
-    ptr::{read_volatile, write_volatile},
-};
+use core::ptr::{read_volatile, write_volatile};
 
 #[cfg(all(not(target_os = "windows"), not(target_os = "freebsd")))]
 use crate::config::AllocationMode;
@@ -24,7 +21,7 @@ impl Detector {
     pub fn new(default: u8, capacity_bytes: usize) -> Self {
         Detector {
             default,
-            detector_mass: repeat_n(default, capacity_bytes).collect(),
+            detector_mass: (0..capacity_bytes).map(|_| default).collect(),
         }
     }
 
@@ -39,7 +36,7 @@ impl Detector {
 
         Detector {
             default,
-            detector_mass: repeat_n(default, capacity_bytes).collect(),
+            detector_mass: (0..capacity_bytes).map(|_| default).collect(),
         }
     }
 
@@ -63,7 +60,7 @@ impl Detector {
 
         Detector {
             default,
-            detector_mass: repeat_n(default, capacity_bytes).collect(),
+            detector_mass: (0..capacity_bytes).map(|_| default).collect(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use core::error::Error;
 use std::{
+    error::Error,
     io::{stdout, Write},
     thread::sleep,
     time::Instant,


### PR DESCRIPTION
Also specify rust-version in Cargo.toml.